### PR TITLE
support file inputs

### DIFF
--- a/form-data-utils/src/index.ts
+++ b/form-data-utils/src/index.ts
@@ -1,5 +1,5 @@
 type FormDataEntryValue = NonNullable<ReturnType<FormData['get']>>;
-type Data = { [key: string]: FormDataEntryValue[] | FormDataEntryValue | string[] | number | Date | File | FileList | null };
+type Data = { [key: string]: FormDataEntryValue[] | FormDataEntryValue | string[] | number | Date | File | File[] | null };
 
 /**
  * A utility function for extracting the FormData as an object
@@ -98,7 +98,7 @@ export function dataFrom(
         }
         case 'file': {
           if (field.files && field.files.length > 0) {
-            data[field.name] = field.multiple ? field.files : field.files[0] || null;
+            data[field.name] = field.multiple ? Array.from(field.files) : field.files[0] || null;
           } else {
             data[field.name] = field.multiple ? [] : null;
           }

--- a/form-data-utils/src/index.ts
+++ b/form-data-utils/src/index.ts
@@ -1,5 +1,5 @@
 type FormDataEntryValue = NonNullable<ReturnType<FormData['get']>>;
-type Data = { [key: string]: FormDataEntryValue[] | FormDataEntryValue | string[] | number | Date | null };
+type Data = { [key: string]: FormDataEntryValue[] | FormDataEntryValue | string[] | number | Date | File | FileList | null };
 
 /**
  * A utility function for extracting the FormData as an object
@@ -17,9 +17,7 @@ export function dataFrom(
     currentTarget: EventTarget | null,
     submitter?: HTMLElement | null | undefined
   },
-): {
-  [name: string]: FormDataEntryValue[] | FormDataEntryValue | string[] | number | Date | null;
-} {
+): Data {
   if (!event) {
     throw new Error(`Cannot call dataFrom with no event`);
   }
@@ -95,6 +93,17 @@ export function dataFrom(
           if (hasMultipleValues) {
             data[field.name] = related.filter(x => x.checked).map(x => x.value);
           }
+
+          break;
+        }
+        case 'file': {
+          if (field.files && field.files.length > 0) {
+            data[field.name] = field.multiple ? field.files : field.files[0] || null;
+          } else {
+            data[field.name] = field.multiple ? [] : null;
+          }
+
+          break;
         }
       }
     }


### PR DESCRIPTION
Supports file inputs, in a way I think it makes most sense:

On single file uploads:
- returns `null` if input is empty
- returns `File` if a file was selected

On multiple file uploads:
- returns `[]` if input is empty
- returns `File[]` if one or more files were selected