### PR TITLE
[Breaking]: normalize values, support non-primitive values, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ function handleSubmit(event) {
   event.preventDefault();
 
   let obj = dataFrom(event);
-  //  ^ { firstName: "NVP", isHuman: "", }
+  //  ^ { firstName: "NVP", isHuman: null, }
 }
 
 <template>
@@ -50,6 +50,98 @@ function handleSubmit(event) {
   </form>
 </template>
 ```
+
+## Non-primitive values
+
+In some cases, you might want to select values that aren't primitive types, e.g selecting a user from a list of users.
+Unfortunately, FormData only supports strings. To work around this, `form-data-utils` provides some utility functions
+to "attach" a non-primitive value to an element:
+
+- `setValue(element: HTMLElement, value: unknown)` - binds a given value to a given element (value can be anything, e.g objects, arrays, etc)
+- `deleteValue(element: HTMLElement)` - undoes a previous `setValue` call
+
+After setting a value with `setValue`, that value will be considered by the `dataFrom` function.
+
+> [!NOTE]  
+> The ideal way to call these functions will probably vary with the framework you're using.
+
+For example, in [Ember.js](https://emberjs.com/), you would use these functions in a modifier that you can then apply to elements.
+
+```gjs
+import { dataFrom, deleteValue as formDeleteValue,setValue as formSetValue } from 'form-data-utils';
+import { modifier } from 'ember-modifier';
+
+// define the ember specific modifier
+const setValue = modifier((element, [value]) => {
+  formSetValue(element, value);
+
+  return () => formDeleteValue(element);
+});
+
+function handleSubmit(event) {
+  event.preventDefault();
+
+  let obj = dataFrom(event);
+  //  ^ { admin: { id: 123, name: 'Sam...' }, user: { id: 321, name: 'Chris...' } }
+}
+
+<template>
+  <form onsubmit={{handleSubmit}}>
+    {{#each users as |user|}}
+      <div>
+        <input type="radio" name="admin" value={{user.id}} {{setValue user}} />
+        <label for={{user.id}}>{{user.name}}</label>
+      </div>
+    {{/each}}
+
+    <select name="user">
+      <option value=""></option>
+
+      {{#each users as |user|}}
+        <option value={{user.id}} {{setValue user}}>{{user.name}}</option>
+      {{/each}}
+    </select>
+
+    <button type="submit">Submit</button>
+  </form>
+</template>
+```
+
+`setValue` (and `deleteValue`) doesn't really care how you call it. It just needs an element and a value, that's it.
+
+> [!NOTE]  
+> `setValue` only supports `<input type="checkbox"`, `<input type="radio"` and `<select`.
+
+> [!WARNING]  
+> The value given by `setValue` has priority. This means that providing both a `value` attribute *and* a value via `setValue` will result in the `value` attribute being ignored by `dataFrom`. However, you might still use the `value` attribute it to create a more meaningful html structure.
+
+
+## Value types normalization
+
+Another thing that `form-data-utils` does is to normalize the types of the values you get back from `dataFrom`. The following table lists the types you get back depending on the various controls available:
+
+| Control              | Type | Default (empty) value |
+| ------------------------- | ------------- | ------------- | 
+| `<input type="text"` (email, search, etc)  | `string`         | `''`            |
+| `<input type="number"`  | `number`       | `null`             |
+| `<input type="range"`    |  `number` |_ranges can't be empty_ |
+| `<input type="date"`      | `Date`    | `null`             |
+| `<input type="datetime-local"`      | `Date`    | `null`   |
+| `<input type="file"`        | [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File)  | `null`             |
+| `<input type="file" multiple` | [`File[]`](https://developer.mozilla.org/en-US/docs/Web/API/File)        | `[]`             |
+| `<input type="checkbox"` without `value` |  `boolean`        | `false`             |
+| `<input type="checkbox"` with `value` |  `GivenValueType`     | `null`             |
+| multiple `<input type="checkbox"` with same `name` without `value` |  `boolean[]`        |  `[]`             |
+| multiple `<input type="checkbox"` with same `name` with `value` |  `GivenValueType[]`        |  `[]`             |
+| `<input type="radio"` | `boolean`        | `false`             |
+| `<input type="radio"` with `value` |  `GivenValueType`      | `null`             |
+| `<select` |  `GivenValueType`        | `null`             |
+| `<select multiple` |  `GivenValueType[]`      | `[]`             |
+| `<button type="submit"` with `name` |  `GivenValueType`       | `null`             |
+
+
+> [!NOTE]  
+> `GivenValueType` here means the type of the value you passed in the `value` attribute **or** using the `setValue(element, value)` function.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -68,14 +68,14 @@ After setting a value with `setValue`, that value will be considered by the `dat
 For example, in [Ember.js](https://emberjs.com/), you would use these functions in a modifier that you can then apply to elements.
 
 ```gjs
-import { dataFrom, deleteValue as formDeleteValue,setValue as formSetValue } from 'form-data-utils';
+import { dataFrom, deleteValue, setValue } from 'form-data-utils';
 import { modifier } from 'ember-modifier';
 
 // define the ember specific modifier
-const setValue = modifier((element, [value]) => {
-  formSetValue(element, value);
+const associateValue = modifier((element, [value]) => {
+  setValue(element, value);
 
-  return () => formDeleteValue(element);
+  return () => deleteValue(element);
 });
 
 function handleSubmit(event) {
@@ -89,7 +89,7 @@ function handleSubmit(event) {
   <form onsubmit={{handleSubmit}}>
     {{#each users as |user|}}
       <div>
-        <input type="radio" name="admin" value={{user.id}} {{setValue user}} />
+        <input type="radio" name="admin" value={{user.id}} {{associateValue user}} />
         <label for={{user.id}}>{{user.name}}</label>
       </div>
     {{/each}}
@@ -98,7 +98,7 @@ function handleSubmit(event) {
       <option value=""></option>
 
       {{#each users as |user|}}
-        <option value={{user.id}} {{setValue user}}>{{user.name}}</option>
+        <option value={{user.id}} {{associateValue user}}>{{user.name}}</option>
       {{/each}}
     </select>
 

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Another thing that `form-data-utils` does is to normalize the types of the value
 | `<input type="checkbox"` with `value` |  `GivenValueType`     | `null`             |
 | multiple `<input type="checkbox"` with same `name` without `value` |  `boolean[]`        |  `[]`             |
 | multiple `<input type="checkbox"` with same `name` with `value` |  `GivenValueType[]`        |  `[]`             |
-| `<input type="radio"` | `boolean`        | `false`             |
+| `<input type="radio"` without `value` | `boolean`        | `false`             |
 | `<input type="radio"` with `value` |  `GivenValueType`      | `null`             |
 | `<select` |  `GivenValueType`        | `null`             |
 | `<select multiple` |  `GivenValueType[]`      | `[]`             |

--- a/form-data-utils/src/index.ts
+++ b/form-data-utils/src/index.ts
@@ -176,15 +176,13 @@ function getRadioCheckboxValue(el: HTMLInputElement) {
   // el.getAttribute('value') returns null when value is not supplied (el.value returns 'on', so we can't use it)
   const isValueDefined = el.getAttribute('value') !== null || getValue(el);
 
-  if (!el.disabled) {
-    if (!isValueDefined) return getValue(el) || el.checked;
+  if (!isValueDefined) return getValue(el) || el.checked;
 
-    if (el.checked) {
-      return getValue(el) || el.value;
-    } else {
-      return null;
-    }
+  if (el.checked) {
+    return getValue(el) || el.value;
   }
+
+  return null;
 }
 
 // utils to allow setting non-primitive values

--- a/test-app/tests/fields/submit-name-test.gts
+++ b/test-app/tests/fields/submit-name-test.gts
@@ -27,10 +27,10 @@ module('dataFrom()', function (hooks) {
       );
 
       await click('button[name=one]');
-      assert.deepEqual(data, { one: '', two: '' });
+      assert.deepEqual(data, { one: null });
 
       await click('button[name=two]');
-      assert.deepEqual(data, { one: '', two: 'second' });
+      assert.deepEqual(data, { two: 'second' });
     });
   });
 });


### PR DESCRIPTION
What started as a way to support non-primitive values ended up as a value normalization quest.

This is a bit to chew on. Perhaps the best description is the README: [See rendered markdown](https://github.com/miguelcobain/form-data-utils/blob/normalization-and-non-primitive/README.md)

I feel like this table summarizes the normalization part very well:

| Control              | Type | Default (empty) value |
| ------------------------- | ------------- | ------------- | 
| `<input type="text"` (email, search, etc)  | `string`         | `''`            |
| `<input type="number"`  | `number`       | `null`             |
| `<input type="range"`    |  `number` |_ranges can't be empty_ |
| `<input type="date"`      | `Date`    | `null`             |
| `<input type="datetime-local"`      | `Date`    | `null`   |
| `<input type="file"`        | [`File`](https://developer.mozilla.org/en-US/docs/Web/API/File)  | `null`             |
| `<input type="file" multiple` | [`File[]`](https://developer.mozilla.org/en-US/docs/Web/API/File)        | `[]`             |
| `<input type="checkbox"` without `value` |  `boolean`        | `false`             |
| `<input type="checkbox"` with `value` |  `GivenValueType`     | `null`             |
| multiple `<input type="checkbox"` with same `name` without `value` |  `boolean[]`        |  `[]`             |
| multiple `<input type="checkbox"` with same `name` with `value` |  `GivenValueType[]`        |  `[]`             |
| `<input type="radio"` without `value` | `boolean`        | `false`             |
| `<input type="radio"` with `value` |  `GivenValueType`      | `null`             |
| `<select` |  `GivenValueType`        | `null`             |
| `<select multiple` |  `GivenValueType[]`      | `[]`             |
| `<button type="submit"` with `name` |  `GivenValueType`       | `null`             |

Feel free to ask any questions! 🙏 